### PR TITLE
feat(PI-4819): add GHA for azure extension publishing

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,36 @@
+name: Lint
+
+on:
+  pull_request:
+  push:
+    tags:
+      - "v*.*.*"
+    branches: [ "main" ]
+
+jobs:
+  version-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check Versions
+        run: |
+          VSS_VERSION=$(jq -r '.version' vss-extension.json)
+          TASK_VERSION=$(jq -j '[.version.Major, .version.Minor, .version.Patch] | join(".")' nowsecure/task.json)
+          if [ "$VSS_VERSION" = "$TASK_VERSION" ]; then
+            echo "Versions match $VSS_VERSION"
+          else
+            echo "Version from vss file ($VSS_VERSION) and task file ($TASK_VERSION) do not match"
+            exit 1
+          fi
+  biome-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: ./nowsecure
+      - name: Biome Check
+        run: npx @biomejs/biome@2 check nowsecure/index.ts

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,121 @@
+name: Workflow
+
+on:
+  pull_request:
+  push:
+    tags:
+      - "v*.*.*"
+    branches: [ "main" ]
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./nowsecure
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: ./nowsecure
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Run Build
+        run: npm run build
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-output
+          path: ./nowsecure/dist/
+
+  package:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download Build
+        uses: actions/download-artifact@v4
+        with:
+          name: build-output
+          path: ./nowsecure/dist/
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: ./nowsecure
+
+      - name: Install TFX
+        run: npm install -g tfx-cli
+
+      - name: Package Extension
+        run: tfx extension create --manifest-globs vss-extension.json
+
+      - name: Upload VSIX
+        uses: actions/upload-artifact@v4
+        with:
+          name: vsix-pr-${{ github.event.pull_request.number }}
+          path: '*.vsix'
+
+  qa-publish:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download Build
+        uses: actions/download-artifact@v4
+        with:
+          name: build-output
+          path: ./nowsecure/dist/
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install TFX
+        run: npm install -g tfx-cli
+
+      - name: Ensure Version Consistency
+        run: |
+          tfx extension publish \
+              --manifest-globs vss-extension.json \
+              --share-with qa-nowsecure \
+              --token $QA_TOKEN
+
+  public-publish:
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download Build
+        uses: actions/download-artifact@v4
+        with:
+          name: build-output
+          path: ./nowsecure/dist/
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install TFX
+        run: npm install -g tfx-cli
+
+      - name: Ensure Version Consistency
+        run: |
+          tfx extension publish \
+            --manifest-globs vss-extension.json \
+            --overrides-file prod-overrides.json
+            --token $PRD_TOKEN


### PR DESCRIPTION
Adds two workflows, one dedicated to linting and another for building / packaging / publishing the project

Note:

The 'workflow' workflow is a bit clunky because it should probably be broken up into three distinct workflows itself, but this would require a bit of additional work. GitHub does let you share artifacts across workflows, but not without a correctly scoped token: https://github.com/actions/download-artifact?tab=readme-ov-file#download-artifacts-from-other-workflow-runs-or-repositories

For this reason, I think it makes sense to get this bigger job working now, and put in a token request in the meantime, with the intention of breaking it apart later.

The existence of an automation of any type is still better than the very manual process we had previously
