### PR TITLE
fix: need to have node_modules in each step

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -54,6 +54,10 @@ jobs:
           cache: 'npm'
           cache-dependency-path: ./nowsecure
 
+      - name: Install Dependencies
+        working-directory: ./nowsecure
+        run: npm ci
+
       - name: Install TFX
         run: npm install -g tfx-cli
 
@@ -85,6 +89,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'npm'
+          cache-dependency-path: ./nowsecure
+
+      - name: Install Dependencies
+        working-directory: ./nowsecure
+        run: npm ci
 
       - name: Install TFX
         run: npm install -g tfx-cli
@@ -114,6 +124,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'npm'
+          cache-dependency-path: ./nowsecure
+
+      - name: Install Dependencies
+        working-directory: ./nowsecure
+        run: npm ci
 
       - name: Install TFX
         run: npm install -g tfx-cli


### PR DESCRIPTION
It probably makes more sense to move these into separate workflows, and have both node_modules and index.js available as build artifacts of those workflows, but there's a desire to publish soon, and short-term this seems fine