### PR TITLE
chore: bump version

### DIFF
--- a/nowsecure/task.json
+++ b/nowsecure/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 1
+        "Patch": 2
     },
     "instanceNameFormat": "nowsecure-azure-ci-extension $(filepath)",
     "groups": [

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -3,7 +3,7 @@
     "id": "nowsecure-azure-ci-extension",
     "name": "NowSecure Azure CI Extension",
     "description": "Azure Extension for NowSecure Security Assessment",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "publisher": "Nowsecure-com",
     "public": false,
     "targets": [


### PR DESCRIPTION
There's no actual code changes here, but the azure publishing command failed previously due to the --share-with flag on a public extension.

The job did publish the extension at v0.1.1 but due to the job failure a clean version bump will look nicer