### PR TITLE
chore: bump version to 0.1.4

### DIFF
--- a/nowsecure/task.json
+++ b/nowsecure/task.json
@@ -11,7 +11,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 3
+        "Patch": 4
     },
     "instanceNameFormat": "nowsecure-azure-ci-extension $(filepath)",
     "groups": [

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -3,7 +3,7 @@
     "id": "nowsecure-azure-ci-extension",
     "name": "NowSecure Azure CI Extension",
     "description": "Azure Extension for NowSecure Security Assessment",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "publisher": "Nowsecure-com",
     "public": false,
     "targets": [


### PR DESCRIPTION
The tfx unpublish command seems to leave extensions in a broken state - where subsequent attemtps to publish that same extension result in the tool saying that the extension doesn't exist so it can't be updated, but also that it already exists so can't be created

It seems like the best solution is to rev versions more often