### PR TITLE
fix(PI-6026): fix typo in update-binary.yml

### DIFF
--- a/.github/workflows/update-binary.yml
+++ b/.github/workflows/update-binary.yml
@@ -26,7 +26,7 @@ jobs:
 
             find . -name 'ns_*' -delete
 
-            gh release --repo nowsecure/nowsecureci download --clobber \
+            gh release --repo nowsecure/nowsecure-ci download --clobber \
               --pattern 'ns_darwin-arm64*' \
               --pattern 'ns_linux-amd64*' \
               --pattern 'ns_windows-amd64*'

--- a/nowsecure/task.json
+++ b/nowsecure/task.json
@@ -11,7 +11,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 5
+        "Patch": 6
     },
     "instanceNameFormat": "nowsecure-azure-ci-extension $(filepath)",
     "groups": [

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -3,7 +3,7 @@
     "id": "nowsecure-azure-ci-extension",
     "name": "NowSecure Azure CI Extension",
     "description": "Azure Extension for NowSecure Security Assessment",
-    "version": "0.1.5",
+    "version": "0.1.6",
     "publisher": "Nowsecure-com",
     "public": false,
     "targets": [


### PR DESCRIPTION
Resolve typo in the update-binary.yml file to ensure that the ns-ci binary is updated when new versions are pushed.

Tested locally:

```
$ gh release --repo nowsecure/nowsecure-ci download --clobber --pattern 'ns_darwin-arm64*'
$  ls
ns_darwin-arm64.tgz
```